### PR TITLE
fix transcript timestamps + add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# samples
+# Transcript samples
+
+This repository contains sample transcripts for the WordCab API. You can use these transcripts to test the API and to 
+see how the API works.
+
+To test the API, you'll need to [sign up for an account](https://wordcab.com/signup) and follow the 
+[quickstart guide](https://docs.wordcab.com/docs/quickstart).

--- a/transcript_samples/sales_call.txt
+++ b/transcript_samples/sales_call.txt
@@ -1,22 +1,22 @@
-[00:00:08 -> 00:00:11] Lauren: Thank you for calling Nissan. My name is Lauren. Can I have your name?
-[00:00:11 -> 00:00:13] Sam: Yeah, my name is John Smith.
-[00:00:13 -> 00:00:15] Lauren: Thank you, John. How can I help you?
-[00:00:16 -> 00:00:20] Sam: I was just calling about to see how much it would cost to update the map in my car.
-[00:00:20 -> 00:00:24] Lauren: Are I'd be happy to help you with that. Stay. Did you receive a Mailer from us?
-[00:00:24 -> 00:00:26] Sam: I did. Do you need the customer number?
-[00:00:26 -> 00:00:27] Lauren: Yes, please.
-[00:00:27 -> 00:00:28] Sam: Okay. It's.
-[00:00:30 -> 00:00:33] Lauren: Thank you. And the year, make and model of your vehicle?
-[00:00:33 -> 00:00:37] Sam: Yeah, I have a 2009 Nissan Altima.
-[00:00:37 -> 00:00:38] Lauren: Oh, nice car.
-[00:00:38 -> 00:00:40] Sam: Yeah. Thank you. We really enjoy it.
-[00:00:41 -> 00:00:46] Lauren: Okay. I think I found your profile here. Can I have you verify your address and phone number, please?
-[00:00:46 -> 00:00:58] Sam: Yes, it's researchway that's in Orem, Utah, 84097. And my phone number is 80143 one 1000.
-[00:00:58 -> 00:01:14] Lauren: Thanks, John. I located your information. The newest version we have available for your vehicle is version 7.7, which was released in March of 2012. The price of the new map is $99 plus shipping and tax. Let me go ahead and set up this order for you.
-[00:01:14 -> 00:01:18] Sam: Well, can we wait just a second? I'm not really sure if I can afford it right now.
-[00:01:19 -> 00:01:31] Lauren: All right, well, here are a few reasons to consider purchasing today. It looks as though you haven't updated your vehicle for three years, so that would be the equivalent of getting three years worth of updates for the price of one.
-[00:01:31 -> 00:01:32] Sam: Okay.
-[00:01:32 -> 00:01:42] Lauren: In addition, special offers like the current promotion don't come around too often. I would definitely recommend taking advantage of the extra $50 off before it expires.
-[00:01:42 -> 00:01:44] Sam: Yeah, that does sound pretty good.
-[00:01:44 -> 00:01:53] Lauren: If I set this order up for you now, it will ship out today and for $50 less. Do you have your credit card handy? And I can place this order for you now?
-[00:01:53 -> 00:01:58] Sam: Yeah, let's go ahead and use a Visa. My number is.
+[00:00:08 --> 00:00:11] Lauren: Thank you for calling Nissan. My name is Lauren. Can I have your name?
+[00:00:11 --> 00:00:13] Sam: Yeah, my name is John Smith.
+[00:00:13 --> 00:00:15] Lauren: Thank you, John. How can I help you?
+[00:00:16 --> 00:00:20] Sam: I was just calling about to see how much it would cost to update the map in my car.
+[00:00:20 --> 00:00:24] Lauren: Are I'd be happy to help you with that. Stay. Did you receive a Mailer from us?
+[00:00:24 --> 00:00:26] Sam: I did. Do you need the customer number?
+[00:00:26 --> 00:00:27] Lauren: Yes, please.
+[00:00:27 --> 00:00:28] Sam: Okay. It's.
+[00:00:30 --> 00:00:33] Lauren: Thank you. And the year, make and model of your vehicle?
+[00:00:33 --> 00:00:37] Sam: Yeah, I have a 2009 Nissan Altima.
+[00:00:37 --> 00:00:38] Lauren: Oh, nice car.
+[00:00:38 --> 00:00:40] Sam: Yeah. Thank you. We really enjoy it.
+[00:00:41 --> 00:00:46] Lauren: Okay. I think I found your profile here. Can I have you verify your address and phone number, please?
+[00:00:46 --> 00:00:58] Sam: Yes, it's researchway that's in Orem, Utah, 84097. And my phone number is 80143 one 1000.
+[00:00:58 --> 00:01:14] Lauren: Thanks, John. I located your information. The newest version we have available for your vehicle is version 7.7, which was released in March of 2012. The price of the new map is $99 plus shipping and tax. Let me go ahead and set up this order for you.
+[00:01:14 --> 00:01:18] Sam: Well, can we wait just a second? I'm not really sure if I can afford it right now.
+[00:01:19 --> 00:01:31] Lauren: All right, well, here are a few reasons to consider purchasing today. It looks as though you haven't updated your vehicle for three years, so that would be the equivalent of getting three years worth of updates for the price of one.
+[00:01:31 --> 00:01:32] Sam: Okay.
+[00:01:32 --> 00:01:42] Lauren: In addition, special offers like the current promotion don't come around too often. I would definitely recommend taking advantage of the extra $50 off before it expires.
+[00:01:42 --> 00:01:44] Sam: Yeah, that does sound pretty good.
+[00:01:44 --> 00:01:53] Lauren: If I set this order up for you now, it will ship out today and for $50 less. Do you have your credit card handy? And I can place this order for you now?
+[00:01:53 --> 00:01:58] Sam: Yeah, let's go ahead and use a Visa. My number is.


### PR DESCRIPTION
I fixed the timestamps in the `sales_call.txt` file. They were missing `-`.

Plus, I have added straightforward content for the `README.md file.